### PR TITLE
added quotes around cpus field in compose.yml

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -9,8 +9,8 @@ services:
       replicas: 2
       resources:
         limits:
-          cpus: 2
+          cpus: '2'
           memory: 2G
         reservations:
-          cpus: 1
+          cpus: '1'
           memory: 1G


### PR DESCRIPTION
fixes:

```
2 error(s) decoding:

* error decoding 'services[runner].deploy.resources.limits.cpus': unexpected value type int for cpus
* error decoding 'services[runner].deploy.resources.reservations.cpus': unexpected value type int for cpus
 ```